### PR TITLE
Use Array.make instead of deprecated Array.create

### DIFF
--- a/distribution.ml
+++ b/distribution.ml
@@ -16,7 +16,7 @@ type uni =
   | Binomial of int * float   (* number, rate *)
   | Exp of float              (* parameter *)
 
-type multi = 
+type multi =
     MVNormal of Matrix.t * Matrix.t  (* mean, covariance matrix *)
 
 type t = Univariate of uni | Multivariate of multi
@@ -32,14 +32,14 @@ type rng = {
 let pi = 4.0 *. (atan 1.0)
 
 (** RNG from standard library (or Core) *)
-let stdrng = { 
-  init = Random.init; 
+let stdrng = {
+  init = Random.init;
   sample = Random.float;
-  sample01 = ( fun () -> Random.float 1.0 ); 
+  sample01 = ( fun () -> Random.float 1.0 );
 }
 
-let sample_bernoulli ?(rng=stdrng) rate = 
-  let u = rng.sample01 () in 
+let sample_bernoulli ?(rng=stdrng) rate =
+  let u = rng.sample01 () in
   if u <= rate then 1.0 else 0.0
 
 let sample_exp ?(rng=stdrng) param =
@@ -53,20 +53,20 @@ let sample_stdnormal_boxmuller rng =
   let x2 = (sqrt (-.2.0 *. (log u1))) *. (sin (2.0 *. pi *. u2)) in
   (x1, x2)
 
-let sample_stdnormal_boxmuller2 rng = 
-  let rec attempt () = 
+let sample_stdnormal_boxmuller2 rng =
+  let rec attempt () =
     let u1 = rng.sample01 () in
     let u2 = rng.sample01 () in
     let s = (u1 ** 2.0) +. (u2 ** 2.0) in
     if s <= 1.0 then (s, u1, u2) else attempt () in
   let s, u1, u2 = attempt () in
   let z = sqrt (-2.0 *. (log s) /. s) in
-  let x1 = z *. u1 in 
+  let x1 = z *. u1 in
   let x2 = z *. u2 in
   (x1, x2)
 
-let sample_stdnormal_boxmuller3 rng = 
-  let rec attempt () = 
+let sample_stdnormal_boxmuller3 rng =
+  let rec attempt () =
     let y1 = sample_exp ~rng 1.0 in
     let y2 = sample_exp ~rng 1.0 in
     if y2 > ((1.0 -. y1) ** 2.0) /. 2.0 then y1 else attempt () in
@@ -74,7 +74,7 @@ let sample_stdnormal_boxmuller3 rng =
   let u = rng.sample01 () in
   if u <= 0.5 then y1 else -.y1
 
-let sample_normal_boxmuller3 ?(rng=stdrng) mu sigma = 
+let sample_normal_boxmuller3 ?(rng=stdrng) mu sigma =
   let z = sample_stdnormal_boxmuller3 rng in
   (sigma *. z) +. mu
 
@@ -82,18 +82,18 @@ let stdnorm_samples smp num =
   let res = Array.init num (fun i -> sample_stdnormal_boxmuller3 smp) in
   Matrix.vector_from_array res
 
-let sample_uni ?(rng=stdrng) d = 
+let sample_uni ?(rng=stdrng) d =
   match d with
     Uniform (low, high) -> let off = high -. low in (rng.sample off) +. low
-  | Exp lambda -> sample_exp ~rng lambda 
+  | Exp lambda -> sample_exp ~rng lambda
   | Bernoulli rate -> sample_bernoulli ~rng rate
   | Normal (mu, sigma) -> sample_normal_boxmuller3 ~rng mu sigma
   | _ -> failwith "Not implemented"  (* FIX *)
 
-let samples_uni_vec ?(rng=stdrng) d n = 
+let samples_uni_vec ?(rng=stdrng) d n =
   Matrix.init_vector n (fun i -> sample_uni d)
 
-(** Sample from a multivariate normal distribution with mean vector 
+(** Sample from a multivariate normal distribution with mean vector
     mu and covariance matrix sigma *)
 let sample_mvnorm ?(rng=stdrng) mu sigma =
   let n = Matrix.vector_size mu in         (* dimension of the MV normal *)
@@ -102,11 +102,11 @@ let sample_mvnorm ?(rng=stdrng) mu sigma =
   let res = Matrix.( cholfact * nsamples ) in
   Matrix.( res + mu )
 
-let samples_mvnorm ?(rng=stdrng) mu sigma ns = 
+let samples_mvnorm ?(rng=stdrng) mu sigma ns =
   let res = Matrix.create (Matrix.vector_size mu) ns in
-  let rec fill_loop i = 
+  let rec fill_loop i =
     if i = ns then ()
-    else 
+    else
       let s = sample_mvnorm ~rng mu sigma in
       Matrix.copy_vec_mat_col s res i;
       fill_loop (i+1) in

--- a/matrix.ml
+++ b/matrix.ml
@@ -28,11 +28,11 @@ type t = {
 exception Incompatible_dimensions
 
 let create ?(initval=0.0) ~rows ~cols = 
-  { rows=rows; cols=cols; entries=Array.create (rows*cols) initval }
+  { rows=rows; cols=cols; entries=Array.make (rows*cols) initval }
 
 (* a vector is just a column-matrix *)
 let create_vector ?(initval=0.0) size = 
-  { rows=size; cols=1; entries=Array.create size initval }
+  { rows=size; cols=1; entries=Array.make size initval }
 
 let from_array ~rows ~cols a = 
   if Array.length a != rows*cols then raise Incompatible_dimensions


### PR DESCRIPTION
Not sure if Array.make imposes a minimum version requirement for the OCaml compiler.

Also another patch with cosmetic fixes to remove trailing whitespace.
